### PR TITLE
pin sub dependencies to use the local video_player_platform_interface

### DIFF
--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -1,4 +1,5 @@
 name: video_player
+publish_to: "none"
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player
@@ -22,10 +23,26 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  video_player_android: ^2.2.17
-  video_player_avfoundation: ^2.2.17
-  video_player_platform_interface: ">=4.2.0 <6.0.0"
-  video_player_web: ^2.0.0
+  video_player_android:
+    git:
+      url: https://github.com/navaronbracke/plugins.git
+      ref: main
+      path: ./packages/video_player/video_player_android
+  video_player_avfoundation:
+    git:
+      url: https://github.com/navaronbracke/plugins.git
+      ref: main
+      path: ./packages/video_player/video_player_avfoundation
+  video_player_platform_interface: 
+    git:
+      url: https://github.com/navaronbracke/plugins.git
+      ref: main
+      path: ./packages/video_player/video_player_platform_interface
+  video_player_web:
+    git:
+      url: https://github.com/navaronbracke/plugins.git
+      ref: main
+      path: ./packages/video_player/video_player_web
   html: ^0.15.0
 
 dev_dependencies:


### PR DESCRIPTION
This PR pins the dependencies on `video_player_platform_interface` to use the version in this repository instead of the published one on Pub.
